### PR TITLE
Add event_regisration.delayed_payment_date_past?

### DIFF
--- a/app/models/concerns/effective_events_event_registration.rb
+++ b/app/models/concerns/effective_events_event_registration.rb
@@ -249,6 +249,11 @@ module EffectiveEventsEventRegistration
       event&.delayed_payment_date_upcoming?
     end
 
+    def delayed_payment_date_past?
+      return false unless event&.delayed?
+      !event&.delayed_payment_date_upcoming?
+    end
+
     def find_or_build_submit_fees
       with_outstanding_coupon_fees(submit_fees)
     end


### PR DESCRIPTION
intended to let us update ability.rb to prevent non-admin users from deleting registrations after the delayed payemnt date with 

```ruby
can(:destroy, EffectiveEvents.EventRegistration) {
  |registration| registration.owner == user 
  && !registration.was_submitted? 
  && !registration.delayed_payment_date_past?
}
```