### PR TITLE
Guard abandon registration dashboard links

### DIFF
--- a/app/views/effective/event_registrations/_dashboard.html.haml
+++ b/app/views/effective/event_registrations/_dashboard.html.haml
@@ -15,9 +15,10 @@
     %p
       Please
       = link_to("Continue registration", effective_events.event_event_registration_build_path(registration.event, registration, registration.next_step), 'data-turbolinks' => false, class: 'btn btn-primary')
-      or you can
-      = link_to('Abandon registration', effective_events.event_event_registration_path(registration.event, registration), 'data-confirm': "Really delete registration for #{registration.event}?", 'data-method': :delete, class: 'btn btn-danger')
-      to register for another event.
+      - if EffectiveResources.authorized?(self, :destroy, registration)
+        or you can
+        = link_to('Abandon registration', effective_events.event_event_registration_path(registration.event, registration), 'data-confirm': "Really delete registration for #{registration.event}?", 'data-method': :delete, class: 'btn btn-danger')
+        to register for another event.
 
   - if registration.submitted?
     %p 
@@ -31,9 +32,10 @@
   - if registration.submitted? && registration.event.delayed_payment_date_upcoming? && registration.can_visit_step?(:tickets)
     %p 
       You can #{link_to('change your registration', effective_events.event_event_registration_build_path(registration.event, registration, :tickets))} until the payment date
-      or
-      = link_to('abandon registration', effective_events.event_event_registration_path(registration.event, registration), 'data-confirm': "Really delete registration for #{registration.event}?", 'data-method': :delete)
-      to cancel and register for another event.
+      - if EffectiveResources.authorized?(self, :destroy, registration)
+        or
+        = link_to('abandon registration', effective_events.event_event_registration_path(registration.event, registration), 'data-confirm': "Really delete registration for #{registration.event}?", 'data-method': :delete)
+        to cancel and register for another event.
 
   %hr
 


### PR DESCRIPTION
## Summary
- only show event registration abandon links when the current user is authorized to destroy the registration
- applies the same guard to draft and delayed-payment dashboard abandon links

## Verification
- Parsed the HAML partial through the host app bundle with Haml::Engine