### PR TITLE
Fix purchased event registrant reassignment

### DIFF
--- a/app/models/effective/event_registrant.rb
+++ b/app/models/effective/event_registrant.rb
@@ -85,7 +85,7 @@ module Effective
       self.owner ||= event_registration.owner
     end
 
-    with_options(unless: -> { purchased? && !blank_registrant_was }) do
+    with_options(unless: -> { purchased? && !blank_registrant_was && !user_changed? }) do
       before_validation(if: -> { blank_registrant? }) do
         assign_attributes(user: nil, organization: nil, first_name: nil, last_name: nil, email: nil, company: nil)
       end
@@ -101,6 +101,11 @@ module Effective
 
       before_validation(if: -> { user.present? }) do
         assign_attributes(first_name: user.first_name, last_name: user.last_name, email: (user.try(:public_email).presence || user.email))
+      end
+
+      before_validation(if: -> { user.present? && user_changed? && user.class.try(:effective_memberships_organization_user?) }) do
+        organization = user.organizations.first
+        assign_attributes(organization: organization, company: organization.to_s.presence)
       end
 
       before_validation(if: -> { organization.blank? && user.present? && user.class.try(:effective_memberships_organization_user?) }) do
@@ -134,7 +139,7 @@ module Effective
 
     # Validate this user isn't already registered for this event ticket on another registration
     # Or for this event on any ticket, when one ticket per event is enabled
-    validate(if: -> { user.present? && event_ticket.present? && registrant_validations_enabled? }, unless: -> { purchased? }) do
+    validate(if: -> { user.present? && event_ticket.present? && (registrant_validations_enabled? || (registered? && !archived? && user_changed?)) }) do
       duplicate_of = (validate_one_ticket_per_event? ? { event: event } : { event_ticket: event_ticket })
 
       if Effective::EventRegistrant.unarchived.registered.where(user: user).where(duplicate_of).where.not(id: id).present?

--- a/test/models/event_registrants_test.rb
+++ b/test/models/event_registrants_test.rb
@@ -217,4 +217,43 @@ class EventRegistrantsTest < ActiveSupport::TestCase
 
     assert_equal ["Unable to register #{user} for #{event}. They've already been registered"], event_registrant.errors[:user_id]
   end
+
+  test 'changing the user on a purchased registrant updates the attendee details' do
+    event_registration = build_event_registration()
+    event_registration.ready!
+    event_registration.submit_order.purchase!
+
+    organization = Organization.create!(title: 'New Organization', email: 'admin@new-organization.com')
+    user = build_user_with_address()
+    user.update!(first_name: 'New', last_name: 'Attendee')
+    user.build_representative(organization: organization).save!
+
+    event_registrant = event_registration.event_registrants.first
+    event_registrant.update!(user: user)
+
+    assert_equal 'New', event_registrant.first_name
+    assert_equal 'Attendee', event_registrant.last_name
+    assert_equal user.email, event_registrant.email
+    assert_equal organization, event_registrant.organization
+    assert_equal organization.to_s, event_registrant.company
+  end
+
+  test 'changing the user on a purchased registrant validates duplicates' do
+    user = build_user_with_address()
+    event_registration = build_event_registration()
+    event = event_registration.event
+    event_registration.event_registrants.first.update!(user: user)
+    event_registration.ready!
+    event_registration.submit_order.purchase!
+
+    duplicate_registration = build_event_registration(event: event)
+    duplicate_registration.ready!
+    duplicate_registration.submit_order.purchase!
+
+    event_registrant = duplicate_registration.event_registrants.first
+    refute event_registrant.update(user: user)
+
+    assert_equal ["Unable to register #{user} for #{event}. They've already been registered"], event_registrant.errors[:user_id]
+    refute_equal user, event_registrant.reload.user
+  end
 end


### PR DESCRIPTION
## Summary
- refresh stored attendee details when a purchased registrant's linked user changes
- run the existing duplicate validation when an active purchased registrant is reassigned
- add focused EventRegistrant model coverage

## Testing
- mise exec -- bin/rails test
- 51 tests, 325 assertions, 0 failures