### PR TITLE
Avoid overriding event registrant organization

### DIFF
--- a/app/models/effective/event_registrant.rb
+++ b/app/models/effective/event_registrant.rb
@@ -103,11 +103,6 @@ module Effective
         assign_attributes(first_name: user.first_name, last_name: user.last_name, email: (user.try(:public_email).presence || user.email))
       end
 
-      before_validation(if: -> { user.present? && user_changed? && user.class.try(:effective_memberships_organization_user?) }) do
-        organization = user.organizations.first
-        assign_attributes(organization: organization, company: organization.to_s.presence)
-      end
-
       before_validation(if: -> { organization.blank? && user.present? && user.class.try(:effective_memberships_organization_user?) }) do
         assign_attributes(company: user.organizations.first.to_s.presence) if company.blank?
       end

--- a/test/models/event_registrants_test.rb
+++ b/test/models/event_registrants_test.rb
@@ -229,7 +229,7 @@ class EventRegistrantsTest < ActiveSupport::TestCase
     user.build_representative(organization: organization).save!
 
     event_registrant = event_registration.event_registrants.first
-    event_registrant.update!(user: user)
+    event_registrant.update!(user: user, organization: organization)
 
     assert_equal 'New', event_registrant.first_name
     assert_equal 'Attendee', event_registrant.last_name


### PR DESCRIPTION
## Summary

- remove the `user_changed?` callback that overwrote an organization assigned by the registration form
- keep attendee name and email synchronization unchanged
- update the model test to reflect assigning the user and organization together

## Regression

The callback added in effective_events 3.4.1 could replace an organization that was still being built while completing a purchased blank ticket. This caused company and organization presence validation failures in Upside.

## Verification

- `mise exec -- bin/rails test` — 51 runs, 325 assertions, 0 failures
- existing BOMA delayed-cheque system tests against this local gem — 3 tests, 717 assertions, 0 failures
- existing BOMA reinstatement system test — 1 test, 176 assertions, 0 failures
