### PR TITLE
Use shared pagination normalization

### DIFF
--- a/app/models/effective/event.rb
+++ b/app/models/effective/event.rb
@@ -107,7 +107,7 @@ module Effective
     scope :external, -> { published.where(external_registration: true) }
 
     scope :paginate, -> (page: nil, per_page: nil) {
-      page = EffectiveResources.normalize_page(page)
+      page = EffectiveResources.normalize_page(page) || 1
       offset = [(page - 1), 0].max * (per_page || EffectiveEvents.per_page)
 
       limit(per_page).offset(offset)

--- a/app/models/effective/event.rb
+++ b/app/models/effective/event.rb
@@ -107,7 +107,7 @@ module Effective
     scope :external, -> { published.where(external_registration: true) }
 
     scope :paginate, -> (page: nil, per_page: nil) {
-      page = (page || 1).to_i
+      page = EffectiveResources.normalize_page(page)
       offset = [(page - 1), 0].max * (per_page || EffectiveEvents.per_page)
 
       limit(per_page).offset(offset)

--- a/app/models/effective/event_search.rb
+++ b/app/models/effective/event_search.rb
@@ -43,7 +43,7 @@ module Effective
 
     # The paginated results
     def results(page: nil)
-      page = (page || 1).to_i
+      page = EffectiveResources.normalize_page(page)
       offset = [(page - 1), 0].max * per_page
 
       events.limit(per_page).offset(offset)

--- a/app/models/effective/event_search.rb
+++ b/app/models/effective/event_search.rb
@@ -43,7 +43,7 @@ module Effective
 
     # The paginated results
     def results(page: nil)
-      page = EffectiveResources.normalize_page(page)
+      page = EffectiveResources.normalize_page(page) || 1
       offset = [(page - 1), 0].max * per_page
 
       events.limit(per_page).offset(offset)


### PR DESCRIPTION
## Summary
- normalize Event.paginate page values through EffectiveResources
- normalize EventSearch results page values through the same shared parser
- keep upper-bound validation outside model pagination

## Dependency
- Requires https://github.com/code-and-effect/effective_resources/pull/60

## Tests
- mise exec -- bundle exec rails test test/models/events_test.rb test/models/event_search_test.rb
- 4 runs, 37 assertions, 0 failures

Duplicate parser contract tests were removed from this downstream gem because that behavior is covered by effective_resources.